### PR TITLE
Inverte ordem no PrintingJob, processando com pdftocairo antes do pdfjam

### DIFF
--- a/app/Helpers/PrintingHelper.php
+++ b/app/Helpers/PrintingHelper.php
@@ -101,14 +101,14 @@ class PrintingHelper
     }
 
     // precisa refatorar
-    public static function pdfx($file, $color) {
+    public static function pdftocairo($file, $color) {
         $pdftocairo = "/usr/bin/pdftocairo";
 
         if (!File::exists($pdftocairo)) {
             throw new \Exception("Instalar pdftocairo: apt install poppler-utils.");
         }
 
-        $pdf = File::dirname($file) . "/" . File::name($file) . "pdfx.pdf";
+        $pdf = File::dirname($file) . "/" . File::name($file) . "pdftocairo.pdf";
 
         $timeout = (int) config('impressoras.gs_timeout');
         $process = new Process([

--- a/app/Jobs/PrintingJob.php
+++ b/app/Jobs/PrintingJob.php
@@ -74,7 +74,7 @@ class PrintingJob implements ShouldQueue
         $this->printing->save();
 
         // salvando caminho do arquivo final processado
-        $filepath_processed = PrintingHelper::pdfx($this->printing->filepath_pdfjam, $this->printing->printer->color);
+        $filepath_processed = PrintingHelper::pdftocairo($this->printing->filepath_pdfjam, $this->printing->printer->color);
 
         // Se falhou a geração do arquivo final, interrompemos o processamento
         if(empty($filepath_processed) ) {

--- a/app/Jobs/PrintingJob.php
+++ b/app/Jobs/PrintingJob.php
@@ -43,12 +43,26 @@ class PrintingJob implements ShouldQueue
             return ;
         }
 
+        // processamento inicial com pdftocairo
+        $filepath_processed = PrintingHelper::pdftocairo($this->printing->filepath_original, $this->printing->printer->color);
+
+        // Se falhou a geração do arquivo, interrompemos o processamento
+        if(empty($filepath_processed) ) {
+            Status::createStatus('failed_in_process_pdf', $this->printing);
+            return;
+        }
+
+        // Se deu certo o arquivo processado, registramos em filepath_processed
+        $this->printing->filepath_processed = $filepath_processed;
+        $this->printing->save();
+
+        // pdfjam, principalmente para n-up
         if (!empty($this->printing->start_page)) {
-            $pdfinfo = PrintingHelper::pdfinfo($this->printing->filepath_original);
+            $pdfinfo = PrintingHelper::pdfinfo($this->printing->filepath_processed);
             // trata possível erro de preenchimento
             $end = min($pdfinfo['pages'], $this->printing->end_page);
             $filepath_pdfjam = PrintingHelper::pdfjam(
-                $this->printing->filepath_original,
+                $this->printing->filepath_processed,
                 $this->printing->shrink,
                 $this->printing->pages_per_sheet,
                 $this->printing->start_page,
@@ -57,7 +71,7 @@ class PrintingJob implements ShouldQueue
         }
         else {
             $filepath_pdfjam = PrintingHelper::pdfjam(
-                $this->printing->filepath_original,
+                $this->printing->filepath_processed,
                 $this->printing->shrink,
                 $this->printing->pages_per_sheet
             );
@@ -73,18 +87,7 @@ class PrintingJob implements ShouldQueue
         $this->printing->filepath_pdfjam = $filepath_pdfjam;
         $this->printing->save();
 
-        // salvando caminho do arquivo final processado
-        $filepath_processed = PrintingHelper::pdftocairo($this->printing->filepath_pdfjam, $this->printing->printer->color);
-
-        // Se falhou a geração do arquivo final, interrompemos o processamento
-        if(empty($filepath_processed) ) {
-            Status::createStatus('failed_in_process_pdf', $this->printing);
-            return;
-        }
-
-        // Se deu certo o arquivo processado, registramos o arquivo final
-        $this->printing->filepath_processed = $filepath_processed;
-        $this->printing->save();
+        // atualiza estado do job
         Status::createStatus('pdf_processed_successfully', $this->printing);
 
         // Enviando para impressora
@@ -97,7 +100,7 @@ class PrintingJob implements ShouldQueue
             ->jobTitle($this->printing->filename)
             ->sides($this->printing->sides)
             ->copies($this->printing->copies)
-            ->file($this->printing->filepath_processed)
+            ->file($this->printing->filepath_pdfjam)
             ->send();
         $this->printing->jobid = $printJob->id();
         $this->printing->save();


### PR DESCRIPTION
O pdftocairo é mais resiliente ao processar arquivos que tenham problema de estrutura, e também lida melhor com documentos no formato paisagem. Em particular, consegue tratar corretamente as listas de presença do Júpiter. Esse PR inverte a ordem no PrintingJob, passando o pdftocairo antes do pdfjam. O Helper pdfx também foi renomeado para deixar mais claro o comando que está sendo executado atualmente.