### PR TITLE
Helper pdfjam: adicionado parâmetro para tratar melhor PDF com fonte embutida

### DIFF
--- a/app/Helpers/PrintingHelper.php
+++ b/app/Helpers/PrintingHelper.php
@@ -81,6 +81,7 @@ class PrintingHelper
         $pdf = File::dirname($file) . "/" . File::name($file) . "pdfjam.pdf";
         $command = [
             $pdfjam, $mode,
+            "--preamble", "\pdfinclusioncopyfonts=1",
             "--a4paper",
             "--nup", $nup,
             "--scale", $scale,


### PR DESCRIPTION
Adiciona --preamble '\pdfinclusioncopyfonts=1' para tratar problemas com fontes embutidas, conforme descrito na seção "some known problems" da página do pdfjam.